### PR TITLE
Add dark mode to main page

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -16,6 +16,18 @@
             color: #fff;
             padding: 5rem 0;
         }
+        /* Dark mode styles */
+        body.dark-mode {
+            background-color: #121212;
+            color: #ffffff;
+        }
+        .navbar.dark-mode, .footer.dark-mode {
+            background-color: #1f1f1f;
+        }
+        .card.dark-mode {
+            background-color: #2c2c2c;
+            color: #ffffff;
+        }
     </style>
 </head>
 <body>
@@ -46,6 +58,8 @@
                     <a class="nav-link" href="/lists">Lists</a>
                 </li>
             </ul>
+            <!-- Dark Mode Toggle Button -->
+            <button id="darkModeToggle" class="btn btn-secondary ms-3">Dark Mode</button>
             <!-- Login Button (will be replaced if a user is logged in) -->
             <a id="loginBtn" href="login" class="btn btn-primary ms-3">Login</a>
         </div>
@@ -176,6 +190,28 @@
                 loginBtn.parentNode.replaceChild(dropdownDiv, loginBtn);
             }
         }
+
+        // Apply dark mode preference from local storage
+        const darkModeEnabled = localStorage.getItem('darkMode') === 'true';
+        if (darkModeEnabled) {
+            document.body.classList.add('dark-mode');
+            document.querySelector('.navbar').classList.add('dark-mode');
+            document.querySelector('.footer').classList.add('dark-mode');
+            document.querySelectorAll('.card').forEach(card => card.classList.add('dark-mode'));
+        }
+
+        // Dark mode toggle button event listener
+        const darkModeToggle = document.getElementById('darkModeToggle');
+        darkModeToggle.addEventListener('click', function () {
+            document.body.classList.toggle('dark-mode');
+            document.querySelector('.navbar').classList.toggle('dark-mode');
+            document.querySelector('.footer').classList.toggle('dark-mode');
+            document.querySelectorAll('.card').forEach(card => card.classList.toggle('dark-mode'));
+
+            // Save dark mode preference to local storage
+            const darkModeEnabled = document.body.classList.contains('dark-mode');
+            localStorage.setItem('darkMode', darkModeEnabled);
+        });
     });
 </script>
 </body>


### PR DESCRIPTION
Add dark mode functionality to the main page.

* Add dark mode toggle button in the navigation bar.
* Add JavaScript function to toggle between light and dark modes.
* Add CSS classes for dark mode styling.
* Apply dark mode preference from local storage on page load.
* Save dark mode preference to local storage when toggled.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CS-3203-team-g/Pantry-Pilot/pull/54?shareId=0eb0056b-80c5-4cb3-bb31-35e6598a7165).